### PR TITLE
Automate start of QEMU with DomA/DomU

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/doma.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/doma.bb
@@ -18,6 +18,8 @@ SRC_URI = "\
     file://doma-unpause.service \
     file://doma-create-ExecStartPost.sh \
     file://doma-create-ExecStop.sh \
+    file://doma-restart-monitor.service \
+    file://doma-restart-monitor-ExecStart.sh \
 "
 
 python () {
@@ -32,6 +34,8 @@ FILES:${PN} = " \
     ${systemd_unitdir}/system/doma-unpause.service \
     ${libdir}/xen/bin/doma-create-ExecStartPost.sh \
     ${libdir}/xen/bin/doma-create-ExecStop.sh \
+    ${systemd_unitdir}/system/doma-restart-monitor.service \
+    ${libdir}/xen/bin/doma-restart-monitor-ExecStart.sh \
 "
 
 SYSTEMD_SERVICE:${PN} = "doma-create.service doma-unpause.service"
@@ -45,8 +49,10 @@ do_install() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/doma-create.service ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/doma-unpause.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/doma-restart-monitor.service ${D}${systemd_unitdir}/system/
 
     install -d ${D}${libdir}/xen/bin
     install -m 0755 ${WORKDIR}/doma-create-ExecStartPost.sh ${D}${libdir}/xen/bin/
     install -m 0755 ${WORKDIR}/doma-create-ExecStop.sh ${D}${libdir}/xen/bin/
+    install -m 0755 ${WORKDIR}/doma-restart-monitor-ExecStart.sh ${D}${libdir}/xen/bin/
 }

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStartPost.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStartPost.sh
@@ -25,7 +25,8 @@ qemu-system-aarch64 \
 -global virtio-mmio.force-legacy=false \
 -device virtio-keyboard-pci,disable-legacy=on,iommu_platform=on \
 -audiodev alsa,id=snd0,out.dev=default \
--device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on & \
+-device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on \
+-device vhost-vsock-pci,guest-cid=3 & \
 QEMU_PID=\$!; \
 sleep 5 && brctl addif xenbr0 vif-emu && ifconfig vif-emu up && \
 wait \${QEMU_PID}" && \

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStop.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStop.sh
@@ -18,5 +18,22 @@
 
 DOMD_ID=$(xl list | awk '{ if ($1 == "DomD") print $2 }') && \
 /usr/bin/xenstore-write /local/domain/${DOMD_ID}/drivers/dom0-qemu-command-monitor/status dead && \
-/usr/sbin/xl destroy DomA; \
+( /usr/sbin/xl destroy DomA || true ); \
 
+# Let's wait for hanging domains to shutdown
+HANGING_DOMAIN_ID_MEMORIZED="";
+
+while true; do
+    HANGING_DOMAIN_ID=$(xl list | awk '{ if ($1 == "(null)") print $2 }');
+
+    if [ "$HANGING_DOMAIN_ID" = "" ]; then
+        if [ -n "$HANGING_DOMAIN_ID_MEMORIZED" ]; then
+             echo "Shutdown of the hanging domain with id '${HANGING_DOMAIN_ID_MEMORIZED}' has finished.";
+        fi
+        exit 0;
+    else
+        HANGING_DOMAIN_ID_MEMORIZED=${HANGING_DOMAIN_ID};
+        echo "Waiting for the hanging domain with id '${HANGING_DOMAIN_ID_MEMORIZED}' to shutdown";
+        sleep 1;
+    fi
+done

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-create.service
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-create.service
@@ -1,5 +1,3 @@
-[Unit]
-Description=Android VM creator service
 # NOTE 1
 # Pay attention that corresponding part for
 # Dom0's backend-ready@block.service is
@@ -15,9 +13,15 @@ Description=Android VM creator service
 # Pay attention, that this file starts and pauses the DomA right away.
 # This is done by intention, as we need to start QEMU in DomD before
 # unpausing the guest domain.
+# NOTE 5
+# This service depends on 'doma-restart-monitor.service', as when that
+# service fails, it is intended to restart DomA.
 
-Requires=backend-ready@block.service
-After=backend-ready@block.service
+[Unit]
+Description=Android VM creator service
+
+Requires=backend-ready@block.service doma-restart-monitor.service
+After=backend-ready@block.service doma-restart-monitor.service
 
 [Service]
 Type=oneshot
@@ -27,6 +31,7 @@ ExecStart=/bin/bash -c '/usr/sbin/xl create /etc/xen/doma.cfg && /usr/sbin/xl pa
 ExecStartPost=/usr/lib/xen/bin/doma-create-ExecStartPost.sh
 
 ExecStop=/usr/lib/xen/bin/doma-create-ExecStop.sh
+OnFailure=/usr/lib/xen/bin/doma-create-ExecStop.sh
 
 Restart=on-failure
 RestartSec=5

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor-ExecStart.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor-ExecStart.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Fetch DomA Xen domain identifier
+DOMA_ID="";
+
+while [ "$DOMA_ID" == "" ]; do
+    DOMA_ID=$(xl list | awk '{ if ($1 == "DomA") print $2 }');
+
+    if [ "$DOMA_ID" = "" ]; then
+        sleep 1
+    else
+        echo "Parsed DOMA_ID is '${DOMA_ID}'";
+    fi
+done
+
+XS_PATH="/local/domain/$DOMA_ID"
+
+# Fetch first availability of the parameter
+until xenstore-read $XS_PATH; do
+    sleep 1
+done
+
+echo "Domain 'DomA' has become available.";
+
+while true; do
+	# Wait for the change in the parameters tree
+    xenstore-watch -n2 $XS_PATH > /dev/null;
+
+    if ! xenstore-read $XS_PATH; then
+        echo "Domain 'DomA' with id '${DOMA_ID}' has become unavailable. \
+Failing to notify dependent services. Will be restarted soon ...";
+        exit 1;
+    fi 
+done

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor.service
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Android VM restart service
+
+[Service]
+Type=simple
+
+ExecStart=/usr/lib/xen/bin/doma-restart-monitor-ExecStart.sh
+
+Restart=on-failure
+RestartSec=5
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-xt-control-domain/recipes-guest/domu/domu.bb
+++ b/meta-xt-control-domain/recipes-guest/domu/domu.bb
@@ -19,6 +19,8 @@ SRC_URI = "\
     file://domu-unpause.service \
     file://domu-create-ExecStartPost.sh \
     file://domu-create-ExecStop.sh \
+    file://domu-restart-monitor.service \
+    file://domu-restart-monitor-ExecStart.sh \
 "
 
 FILES:${PN} = " \
@@ -29,6 +31,8 @@ FILES:${PN} = " \
     ${systemd_unitdir}/system/domu-unpause.service \
     ${libdir}/xen/bin/domu-create-ExecStartPost.sh \
     ${libdir}/xen/bin/domu-create-ExecStop.sh \
+    ${systemd_unitdir}/system/domu-restart-monitor.service \
+    ${libdir}/xen/bin/domu-restart-monitor-ExecStart.sh \
 "
 
 SYSTEMD_SERVICE:${PN} = "domu-create.service domu-unpause.service"
@@ -43,8 +47,10 @@ do_install() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/domu-create.service ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/domu-unpause.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/domu-restart-monitor.service ${D}${systemd_unitdir}/system/
 
     install -d ${D}${libdir}/xen/bin
     install -m 0755 ${WORKDIR}/domu-create-ExecStartPost.sh ${D}${libdir}/xen/bin/
     install -m 0755 ${WORKDIR}/domu-create-ExecStop.sh ${D}${libdir}/xen/bin/
+    install -m 0755 ${WORKDIR}/domu-restart-monitor-ExecStart.sh ${D}${libdir}/xen/bin/
 }

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStop.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStop.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 
 DOMD_ID=$(xl list | awk '{ if ($1 == "DomD") print $2 }') && \
-/usr/sbin/xl destroy DomU && \
+( /usr/sbin/xl destroy DomU || true ) && \
 /usr/bin/xenstore-write /local/domain/${DOMD_ID}/drivers/dom0-qemu-command-monitor/status dead;
 
+# Let's wait for hanging domains to shutdown
+HANGING_DOMAIN_ID_MEMORIZED="";
+
+while true; do
+    HANGING_DOMAIN_ID=$(xl list | awk '{ if ($1 == "(null)") print $2 }');
+
+    if [ "$HANGING_DOMAIN_ID" = "" ]; then
+        if [ -n "$HANGING_DOMAIN_ID_MEMORIZED" ]; then
+             echo "Shutdown of the hanging domain with id '${HANGING_DOMAIN_ID_MEMORIZED}' has finished.";
+        fi
+        exit 0;
+    else
+        HANGING_DOMAIN_ID_MEMORIZED=${HANGING_DOMAIN_ID};
+        echo "Waiting for the hanging domain with id '${HANGING_DOMAIN_ID_MEMORIZED}' to shutdown";
+        sleep 1;
+    fi
+done

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-create.service
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-create.service
@@ -2,9 +2,17 @@
 # Pay attention, that this file starts and pauses the DomU right away.
 # This is done by intention, as we need to start QEMU in DomD before
 # unpausing the guest domain.
+# NOTE 2
+# DomU should be started after DomD, as there are parameters across
+# the system, which rely on DomD having the Xen domain id equal to '1'
+# NOTE 3
+# This service depends on 'doma-restart-monitor.service', as when that
+# service fails, it is intended to restart DomA.
 
 [Unit]
 Description=DomU VM creator service
+Requires=domd.service domu-restart-monitor.service
+After=domd.service domu-restart-monitor.service
 
 [Service]
 Type=oneshot
@@ -14,6 +22,7 @@ ExecStart=/bin/bash -c '/usr/sbin/xl create /etc/xen/domu.cfg && /usr/sbin/xl pa
 ExecStartPost=/usr/lib/xen/bin/domu-create-ExecStartPost.sh
 
 ExecStop=/usr/lib/xen/bin/domu-create-ExecStop.sh
+OnFailure=/usr/lib/xen/bin/doma-create-ExecStop.sh
 
 Restart=on-failure
 RestartSec=5

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor-ExecStart.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor-ExecStart.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Fetch DomU Xen domain identifier
+DOMU_ID="";
+
+while [ "$DOMU_ID" == "" ]; do
+    DOMU_ID=$(xl list | awk '{ if ($1 == "DomU") print $2 }');
+
+    if [ "$DOMU_ID" = "" ]; then
+        sleep 1
+    else
+        echo "Parsed DOMU_ID is '${DOMU_ID}'";
+    fi
+done
+
+XS_PATH="/local/domain/$DOMU_ID"
+
+# Fetch first availability of the parameter
+until xenstore-read $XS_PATH; do
+    sleep 1
+done
+
+echo "Domain 'DomU' has become available.";
+
+while true; do
+    # Wait for the change in the parameters tree
+    xenstore-watch -n2 $XS_PATH > /dev/null;
+
+    if ! xenstore-read $XS_PATH; then
+        echo "Domain 'DomU' with id '${DOMU_ID}' has become unavailable. \
+Failing to notify dependent services. Will be restarted soon ...";
+        exit 1;
+    fi 
+done

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor.service
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=DomU VM restart service
+
+[Service]
+Type=simple
+
+ExecStart=/usr/lib/xen/bin/domu-restart-monitor-ExecStart.sh
+
+Restart=on-failure
+RestartSec=5
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Another thing which we need to do in order to pass the CTS is to be able to survive the reboot of the device, as such operation takes place a lot during the CTS execution.

From the Xen point of view, it means, that we need to survive when domain is being reboot by itself, without triggering "xl destory DomA/DomU" or something like that.

In order to achieve that, and to preserve restart of QEMU together with the target guest domain, the following things were done:

- 'domu-restart-monitor' service was introduced
- Added dependency of the 'domu-create' service from the 'domu-restart-monitor' service
- 'doma-restart-monitor' service was introduced
- Added dependency of the 'doma-create' service from the 'doma-restart-monitor' service
- Extended the 'doma-create-ExecStop.sh' script
- Extended the 'domu-create-ExecStop.sh' script
- Added 'doma-create-ExecStop.sh' as 'OnFailure' action for the 'doma-restart-monitor' service
- Added 'domu-create-ExecStop.sh' as 'OnFailure' action for the 'domu-restart-monitor' service

On top of that the following minor fixes took place:

- Added usage of the vhost-vsock-pci device to QEMU
- Added dependency to 'domu-create.service' service on the 'domd' service to preserve start order of the domains. DomD should start before DomU.