### PR TITLE
Start QEMU in the fulscreen mode

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStartPost.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-create-ExecStartPost.sh
@@ -26,7 +26,8 @@ qemu-system-aarch64 \
 -device virtio-keyboard-pci,disable-legacy=on,iommu_platform=on \
 -audiodev alsa,id=snd0,out.dev=default \
 -device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on \
--device vhost-vsock-pci,guest-cid=3 & \
+-device vhost-vsock-pci,guest-cid=3 \
+-full-screen & \
 QEMU_PID=\$!; \
 sleep 5 && brctl addif xenbr0 vif-emu && ifconfig vif-emu up && \
 wait \${QEMU_PID}" && \

--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor-ExecStart.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-restart-monitor-ExecStart.sh
@@ -30,5 +30,5 @@ while true; do
         echo "Domain 'DomA' with id '${DOMA_ID}' has become unavailable. \
 Failing to notify dependent services. Will be restarted soon ...";
         exit 1;
-    fi 
+    fi
 done

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStartPost.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStartPost.sh
@@ -24,7 +24,8 @@ qemu-system-aarch64 \
 -global virtio-mmio.force-legacy=false \
 -device virtio-keyboard-pci,disable-legacy=on,iommu_platform=on \
 -audiodev alsa,id=snd0,out.dev=default \
--device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on & \
+-device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on \
+-full-screen & \
 QEMU_PID=\$!; \
 sleep 5 && brctl addif xenbr0 vif-emu && ifconfig vif-emu up && \
 wait \${QEMU_PID}" && \

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor-ExecStart.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-restart-monitor-ExecStart.sh
@@ -30,5 +30,5 @@ while true; do
         echo "Domain 'DomU' with id '${DOMU_ID}' has become unavailable. \
 Failing to notify dependent services. Will be restarted soon ...";
         exit 1;
-    fi 
+    fi
 done


### PR DESCRIPTION
Some of the CTS fail due to the too small resolution.

This patch is intended to run QEMU in the fullscreen mode.