### PR TITLE
DomU: Add vhost-vsock-pci param to QEMU

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStart.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-create-ExecStart.sh
@@ -33,6 +33,7 @@ qemu-system-aarch64 \
 -device virtio-keyboard-pci,disable-legacy=on,iommu_platform=on \
 -audiodev alsa,id=snd0,out.dev=default \
 -device virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on & \
+-device vhost-vsock-pci,guest-cid=3,disable-legacy=on,iommu_platform=on & \
 QEMU_PID=\$!; \
 sleep 5 && brctl addif xenbr0 vif-emu && ifconfig vif-emu up && \
 sleep 3 && \


### PR DESCRIPTION
We want to try out the vsock communication in the DomU. That might clarify why it does not work in DomA.