### PR TITLE
domu(a)-clean-xenstore.sh: Reset online entry as well

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/files/doma-clean-xenstore.sh
+++ b/meta-xt-control-domain/recipes-guest/doma/files/doma-clean-xenstore.sh
@@ -7,4 +7,5 @@ do
     i=${i%\"}
     i=${i#\"}
     xenstore-write $i/state "6"
+    xenstore-write $i/online "0"
 done

--- a/meta-xt-control-domain/recipes-guest/domu/files/domu-clean-xenstore.sh
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu-clean-xenstore.sh
@@ -7,4 +7,5 @@ do
     i=${i%\"}
     i=${i#\"}
     xenstore-write $i/state "6"
+    xenstore-write $i/online "0"
 done


### PR DESCRIPTION
As it turned out, we would also need to set "online" to "0" in some cases (this was noticed with Qemu in DomD).